### PR TITLE
Fix Bug on Color

### DIFF
--- a/beamercolorthemeGI.sty
+++ b/beamercolorthemeGI.sty
@@ -39,7 +39,7 @@
 \setbeamercolor*{frametitle}{fg=uaf blue}
 
 
-\setbeamercolor*{separation line}{black}
+\setbeamercolor*{separation line}{fg=black}
 \setbeamercolor*{fine separation line}{}
 
 


### PR DESCRIPTION
It looks like something has changed, and now `fg=` is needed when providing a color.  This change put an end to error messages I was getting.  I am using:

```
\pdfminorversion=4		% Compatibility with Adobe Acrobat
\documentclass{beamer}
\usetheme[headline,footline,color]{GI}
```
